### PR TITLE
add 'nodiv' class to completely omit <div> container around list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,6 @@ For more information, visit the official plugin page at https://www.dokuwiki.org
 
 Changes log are maintained on the [official plugin page](https://www.dokuwiki.org/plugin:datatemplate).
 
+2018-05-16 - (only in hci.ur.de fork)  Added a custom class that can be added to the datatemplatelist line: "nodiv". This prevents generation of ``<div>``tags around each data item when generating the list. Necessary for plugins that do not want individual items to be placed into divs (e.g. the [Bootstrap Wrapper plugin](http://www.lotar.altervista.org/wiki/wiki/plugin/bootswrapper)'s [carousel](http://www.lotar.altervista.org/wiki/wiki/plugin/bootswrapper/carousel)
+
 2016-07 - The original author, [Christoph Clausen](https://github.com/ccl/dokuwiki-plugin-datatemplate), cannot maintain anymore the plugin, so I adopt it ;-) Thanks a lot to him to have built first steps and accepted the adoption.

--- a/action.php
+++ b/action.php
@@ -23,12 +23,12 @@ class action_plugin_datatemplate extends DokuWiki_Action_Plugin {
      */
     function getInfo(){
         return array(
-            'author' => 'Cyrille Giquello, Christoph Clausen',
+            'author' => 'Cyrille Giquello, Christoph Clausen, Raphael Wimmer',
             'email'  => '',
-            'date'   => '2016-08-02',
-            'name'   => 'Datatemplate Plugin',
+            'date'   => '2017-11-07',
+            'name'   => 'Datatemplate Plugin (nodiv fork)',
             'desc'   => 'A template extension for the data plugin',
-            'url'    => 'https://github.com/Cyrille37/dokuwiki-plugin-datatemplate',
+            'url'    => 'https://github.com/Medieninformatik-Regensburg/dokuwiki-plugin-datatemplate/archive/master.zip',
             );
     }
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,6 +1,6 @@
 base    datatemplate
 author  Cyrille Giquello, Christoph Clausen, Raphael Wimmer
-date    2017-11-07
-name    Data Template Plugin (nodiv version)
-desc    Extension to the data plugin allowing for the use of templates (including custom nodiv extension for hci.ur.de).
+date    2019-03-20
+name    Data Template Plugin (UR version)
+desc    Extension to the data plugin allowing for the use of templates (including custom nodiv extension for hci.ur.de and handling of HTML content in data fields).
 url     https://github.com/Medieninformatik-Regensburg/dokuwiki-plugin-datatemplate

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,6 +1,6 @@
 base    datatemplate
-author  Cyrille Giquello, Christoph Clausen
-date    2016-08-03
-name    Data Template Plugin
-desc    Extension to the data plugin allowing for the use of templates.
-url     https://github.com/Cyrille37/dokuwiki-plugin-datatemplate
+author  Cyrille Giquello, Christoph Clausen, Raphael Wimmer
+date    2017-11-07
+name    Data Template Plugin (nodiv version)
+desc    Extension to the data plugin allowing for the use of templates (including custom nodiv extension for hci.ur.de).
+url     https://github.com/Medieninformatik-Regensburg/dokuwiki-plugin-datatemplate

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -271,6 +271,10 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                         if(!$sz) $sz = 40;
                         $title = $column['key'].': '.basename(str_replace(':','/',$val));
                         $outs[] = '{{' . $val. ($sz ? '?'.$sz:'') .'|'.$title. '}}';
+                    }else if (strlen($type) > 0){
+                        # by default treat fields with a type as containing HTML in order to be compatible with the data plugin's custom datatypes 
+                        # (which return HTML code). May open up security issues if users can enter HTML code into such fields.
+                        $outs[] = '<html>' . $val . '</html>; 
                     }else{
                         $outs[] = $val;
                     }

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -13,6 +13,7 @@ if(file_exists($dataEntryFile)){
     msg('datatemplate: Cannot find Data plugin.', -1);
     return;
 }
+require_once(DOKU_INC . 'inc/common.php'); // for dformat()
 
 class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
 
@@ -264,6 +265,10 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
                     $outs[] = $val;
                     break;
+		 case 'timestamp':
+		 case 'date':
+                    $outs[] = dformat($val);
+                    break;
                 default:
                     $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
                     if(substr($type,0,3) == 'img'){
@@ -278,7 +283,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     }else{
                         $outs[] = $val;
                     }
-            }    //todo add type 'timestamp' ... returns html..
+            }
         }
         return join(', ',$outs);
     }

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -274,7 +274,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     }else if (strlen($type) > 0){
                         # by default treat fields with a type as containing HTML in order to be compatible with the data plugin's custom datatypes 
                         # (which return HTML code). May open up security issues if users can enter HTML code into such fields.
-                        $outs[] = '<html>' . $val . '</html>; 
+                        $outs[] = '<html>' . $val . '</html>'; 
                     }else{
                         $outs[] = $val;
                     }

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -178,7 +178,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
         $replacers['vals'] = array();
 
         foreach($data['data'] as $key => $val){
-            if($val == '' || !count($val)) continue;
+            if($val == '' || ($val instanceof Countable && !count($val))) continue;
 
             $replacers['keys'][]     = "@@" . $key . "@@";
             $replacers['raw_keys'][] = "@@!" . $key . "@@";

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -143,7 +143,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
 
         // remove toc, section edit buttons and category tags
         $patterns = array('!<div class="toc">.*?(</div>\n</div>)!s',
-                          '#<!-- EDIT.*? \[(\d*-\d*)\] -->#e',
+                          '#<!-- EDIT.*? \[(\d*-\d*)\] -->#',
                           '!<div class="category">.*?</div>!s');
         $replace  = array('','','');
         $text = preg_replace($patterns,$replace,$text);

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -111,10 +111,10 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
      * Generate wiki output from instructions
      *
      * @param $data array as returned by handle()
-     * @param &$R Doku_Renderer_xhtml
+     * @param $R Doku_Renderer_xhtml
      * @return bool|void
      */
-    function _showData($data, &$R) {
+    function _showData($data, $R) {
 
         if(!array_key_exists('template', $data)) {
             // If keyword "template" not present, we can leave

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -13,6 +13,7 @@ if(file_exists($dataEntryFile)){
     msg('datatemplate: Cannot find Data plugin.', -1);
     return;
 }
+require_once(DOKU_INC . 'inc/common.php'); // for dformat()
 
 class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
 
@@ -264,6 +265,9 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
                     $outs[] = $val;
                     break;
+		 case 'timestamp':
+                    $outs[] = dformat($val);
+                    break;
                 default:
                     $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
                     if(substr($type,0,3) == 'img'){
@@ -278,7 +282,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     }else{
                         $outs[] = $val;
                     }
-            }    //todo add type 'timestamp' ... returns html..
+            }
         }
         return join(', ',$outs);
     }

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -206,7 +206,9 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         $rawFile = io_readfile($file);
 
         // embed the included page
-        $R->doc .= "<div class=\"${data['classes']}\">";
+        if(strcmp($data['classes'],'nodiv') !== 0){
+            $R->doc .= "<div class=\"${data['classes']}\">";
+        }
 
         // We only want to call the parser once, so first do all the raw replacements and concatenate
         // the strings.
@@ -257,8 +259,10 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         $text = preg_replace('/@@.*?@@/', '', $text);
 
         $R->doc .= $text;
-        $R->doc .= '</div>';
 
+        if(strcmp($data['classes'],'nodiv') !== 0){
+            $R->doc .= '</div>';
+        }
         return true;
     }
 

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -394,7 +394,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         return preg_match('/^\s*'.$regex.'$/im', $haystack);
     }
 
-    function nullList($data, $clist, &$R) {
+    function nullList($data, $clist, $R) {
         $R->doc .= '<div class="templatelist">Nothing.</div>';
     }
 }

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -241,7 +241,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         $text = p_render('xhtml', $instr, $info);
         // remove toc, section edit buttons and category tags
         $patterns = array('!<div class="toc">.*?(</div>\n</div>)!s',
-                          '#<!-- SECTION \[(\d*-\d*)\] -->#e',
+                          '#<!-- SECTION \[(\d*-\d*)\] -->#',
                           '!<div class="category">.*?</div>!s');
         $replace  = array('','','');
         $text = preg_replace($patterns,$replace,$text);


### PR DESCRIPTION
Sometimes the `<div>` container around the list can be annoying - e.g., if embedding the `datatemplatelist` output into another widget.
This commit allows the user to specifiy a "nodiv" class after the "datatemplatelist" string so that the `<div>` container for the list is omitted.
While a "nodiv" config option would have been more elegant, this would also have required extending the `data` plugin and implementing this feature in all output formats.