### PR TITLE
Fix fatal error on missing template

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,6 @@ For more information, visit the official plugin page at https://www.dokuwiki.org
 
 Changes log are maintained on the [official plugin page](https://www.dokuwiki.org/plugin:datatemplate).
 
+2018-05-16 - (only in hci.ur.de fork)  Added a custom class that can be added to the datatemplatelist line: "nodiv". This prevents generation of ``<div>``tags around each data item when generating the list. Necessary for plugins that do not want individual items to be placed into divs (e.g. the [Bootstrap Wrapper plugin](http://www.lotar.altervista.org/wiki/wiki/plugin/bootswrapper)'s [carousel](http://www.lotar.altervista.org/wiki/wiki/plugin/bootswrapper/carousel)
+
 2016-07 - The original author, [Christoph Clausen](https://github.com/ccl/dokuwiki-plugin-datatemplate), cannot maintain anymore the plugin, so I adopt it ;-) Thanks a lot to him to have built first steps and accepted the adoption.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dokuwiki-plugin-datatemplate
+# dokuwiki-plugin-datatemplate (hci.ur.de fork)
 Extension to the data plugin allowing for the use of templates.
 
 For more information, visit the official plugin page at https://www.dokuwiki.org/plugin:datatemplate.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ For more information, visit the official plugin page at https://www.dokuwiki.org
 
 ## Development status
 
-Changes log are maintained on the [official plugin page](https://www.dokuwiki.org/plugin:datatemplate).
+Changelog is maintained on the [official plugin page](https://www.dokuwiki.org/plugin:datatemplate).
+Here's just the changelog for the hci.ur.de fork
+
+2024-03-22 - fix compatiblity issues caused mainly by a [commit renaming function in the data plugin](https://github.com/splitbrain/dokuwiki-plugin-data/commit/820f7b69ab991d98fcb477d9c2cf41aaecde87ec). 
 
 2018-05-16 - (only in hci.ur.de fork)  Added a custom class that can be added to the datatemplatelist line: "nodiv". This prevents generation of ``<div>``tags around each data item when generating the list. Necessary for plugins that do not want individual items to be placed into divs (e.g. the [Bootstrap Wrapper plugin](http://www.lotar.altervista.org/wiki/wiki/plugin/bootswrapper)'s [carousel](http://www.lotar.altervista.org/wiki/wiki/plugin/bootswrapper/carousel)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more information, visit the official plugin page at https://www.dokuwiki.org
 Changelog is maintained on the [official plugin page](https://www.dokuwiki.org/plugin:datatemplate).
 Here's just the changelog for the hci.ur.de fork
 
-2024-03-22 - fix compatiblity issues caused mainly by a [commit renaming function in the data plugin](https://github.com/splitbrain/dokuwiki-plugin-data/commit/820f7b69ab991d98fcb477d9c2cf41aaecde87ec). 
+2024-03-22 - fix compatiblity issues caused mainly by a [commit renaming functions in the data plugin](https://github.com/splitbrain/dokuwiki-plugin-data/commit/820f7b69ab991d98fcb477d9c2cf41aaecde87ec). 
 
 2018-05-16 - (only in hci.ur.de fork)  Added a custom class that can be added to the datatemplatelist line: "nodiv". This prevents generation of ``<div>``tags around each data item when generating the list. Necessary for plugins that do not want individual items to be placed into divs (e.g. the [Bootstrap Wrapper plugin](http://www.lotar.altervista.org/wiki/wiki/plugin/bootswrapper)'s [carousel](http://www.lotar.altervista.org/wiki/wiki/plugin/bootswrapper/carousel)
 

--- a/action.php
+++ b/action.php
@@ -23,12 +23,12 @@ class action_plugin_datatemplate extends DokuWiki_Action_Plugin {
      */
     function getInfo(){
         return array(
-            'author' => 'Cyrille Giquello, Christoph Clausen',
+            'author' => 'Cyrille Giquello, Christoph Clausen, Raphael Wimmer',
             'email'  => '',
-            'date'   => '2016-08-02',
-            'name'   => 'Datatemplate Plugin',
+            'date'   => '2017-11-07',
+            'name'   => 'Datatemplate Plugin (nodiv fork)',
             'desc'   => 'A template extension for the data plugin',
-            'url'    => 'https://github.com/Cyrille37/dokuwiki-plugin-datatemplate',
+            'url'    => 'https://github.com/Medieninformatik-Regensburg/dokuwiki-plugin-datatemplate/archive/master.zip',
             );
     }
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,6 +1,6 @@
 base    datatemplate
 author  Cyrille Giquello, Christoph Clausen, Raphael Wimmer
-date    2017-11-07
-name    Data Template Plugin (nodiv version)
-desc    Extension to the data plugin allowing for the use of templates (including custom nodiv extension for hci.ur.de).
+date    2019-03-20
+name    Data Template Plugin (UR version)
+desc    Extension to the data plugin allowing for the use of templates (including custom nodiv extension for hci.ur.de and handling of HTML content in data fields).
 url     https://github.com/Medieninformatik-Regensburg/dokuwiki-plugin-datatemplate

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,6 +1,6 @@
 base    datatemplate
 author  Cyrille Giquello, Christoph Clausen, Raphael Wimmer
-date    2019-03-20
+date    2021-07-09
 name    Data Template Plugin (UR version)
 desc    Extension to the data plugin allowing for the use of templates (including custom nodiv extension for hci.ur.de and handling of HTML content in data fields).
 url     https://github.com/Medieninformatik-Regensburg/dokuwiki-plugin-datatemplate

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,6 +1,6 @@
 base    datatemplate
-author  Cyrille Giquello, Christoph Clausen
-date    2016-08-03
-name    Data Template Plugin
-desc    Extension to the data plugin allowing for the use of templates.
-url     https://github.com/Cyrille37/dokuwiki-plugin-datatemplate
+author  Cyrille Giquello, Christoph Clausen, Raphael Wimmer
+date    2017-11-07
+name    Data Template Plugin (nodiv version)
+desc    Extension to the data plugin allowing for the use of templates (including custom nodiv extension for hci.ur.de).
+url     https://github.com/Medieninformatik-Regensburg/dokuwiki-plugin-datatemplate

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -271,6 +271,10 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                         if(!$sz) $sz = 40;
                         $title = $column['key'].': '.basename(str_replace(':','/',$val));
                         $outs[] = '{{' . $val. ($sz ? '?'.$sz:'') .'|'.$title. '}}';
+                    }else if (strlen($type) > 0){
+                        # by default treat fields with a type as containing HTML in order to be compatible with the data plugin's custom datatypes 
+                        # (which return HTML code). May open up security issues if users can enter HTML code into such fields.
+                        $outs[] = '<html>' . $val . '</html>; 
                     }else{
                         $outs[] = $val;
                     }

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -13,6 +13,7 @@ if(file_exists($dataEntryFile)){
     msg('datatemplate: Cannot find Data plugin.', -1);
     return;
 }
+require_once(DOKU_INC . 'inc/common.php'); // for dformat()
 
 class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
 
@@ -264,6 +265,10 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
                     $outs[] = $val;
                     break;
+		 case 'timestamp':
+		 case 'date':
+                    $outs[] = dformat($val);
+                    break;
                 default:
                     $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
                     if(substr($type,0,3) == 'img'){
@@ -278,7 +283,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     }else{
                         $outs[] = $val;
                     }
-            }    //todo add type 'timestamp' ... returns html..
+            }
         }
         return join(', ',$outs);
     }

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -274,7 +274,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     }else if (strlen($type) > 0){
                         # by default treat fields with a type as containing HTML in order to be compatible with the data plugin's custom datatypes 
                         # (which return HTML code). May open up security issues if users can enter HTML code into such fields.
-                        $outs[] = '<html>' . $val . '</html>; 
+                        $outs[] = '<html>' . $val . '</html>'; 
                     }else{
                         $outs[] = $val;
                     }

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -178,7 +178,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
         $replacers['vals'] = array();
 
         foreach($data['data'] as $key => $val){
-            if($val == '' || !count($val)) continue;
+            if($val == '' || ($val instanceof Countable && !count($val))) continue;
 
             $replacers['keys'][]     = "@@" . $key . "@@";
             $replacers['raw_keys'][] = "@@!" . $key . "@@";

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -120,7 +120,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
         if(!array_key_exists('template', $data)) {
             // If keyword "template" not present, we can leave
             // the rendering to the parent class.
-            parent::_showData($data, $R);
+            parent::showData($data, $R);
             return true;
         }
 
@@ -232,13 +232,13 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
             if (is_array($type)) $type = $type['type'];
             switch($type){
                 case 'page':
-                    $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
+                    $val = $this->dthlp->addPrePostFixes($column['type'], $val);
                     $outs[] = '[[' . $val. ']]';
                     break;
                 case 'pageid':
                 case 'title':
                     list($id,$title) = explode('|',$val,2);
-                    $id = $this->dthlp->_addPrePostFixes($column['type'], $id);
+                    $id = $this->dthlp->addPrePostFixes($column['type'], $id);
                     $outs[] = '[[' . $id . '|' . $title . ']]';
                     break;
                 case 'nspage':
@@ -248,11 +248,11 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     break;
                 case 'mail':
                     list($id,$title) = explode(' ',$val,2);
-                    $id = $this->dthlp->_addPrePostFixes($column['type'], $id);
+                    $id = $this->dthlp->addPrePostFixes($column['type'], $id);
                     $outs[] = '[[' . $id . '|' . $title . ']]';
                     break;
                 case 'url':
-                    $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
+                    $val = $this->dthlp->addPrePostFixes($column['type'], $val);
                     $outs[] = '[[' . $val . ']]';
                     break;
                 case 'tag':
@@ -262,7 +262,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                         '" class="wikilink1">'.hsc($val).'</a>';
                     break;
                 case 'wiki':
-                    $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
+                    $val = $this->dthlp->addPrePostFixes($column['type'], $val);
                     $outs[] = $val;
                     break;
 		 case 'timestamp':
@@ -272,7 +272,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     $outs[] = $val;
                     break;
                 default:
-                    $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
+                    $val = $this->dthlp->addPrePostFixes($column['type'], $val);
                     if(substr($type,0,3) == 'img'){
                         $sz = (int) substr($type,3);
                         if(!$sz) $sz = 40;
@@ -299,7 +299,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
      */
     function _saveRendereredData($data,$id,&$renderer){
         if(!array_key_exists('template', $data)) {
-            parent::_saveData($data, $id, $renderer->meta['title']);
+            parent::saveData($data, $id, $renderer->meta['title']);
             return;
         }
 
@@ -308,7 +308,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
         // If for some reason there are no instructions, don't do anything
         // (Maybe for cache handling one should hand the template file name to the
         // metadata, even though the file does not exist)
-        if(!is_string($file)) parent::_saveData($data, $id, $renderer->meta['title']);
+        if(!is_string($file)) parent::saveData($data, $id, $renderer->meta['title']);
         $renderer->meta['relation']['haspart'][$file] = array('owner'=>$this->getPluginName());
 
         // Remove document_start and document_end from instructions
@@ -320,7 +320,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
             call_user_func_array(array($renderer, $instr[$i][0]), $instr[$i][1]);
         }
 
-        parent::_saveData($data, $id, $renderer->meta['title']);
+        parent::saveData($data, $id, $renderer->meta['title']);
     }
 }
 /* Local Variables: */

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -143,7 +143,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
 
         // remove toc, section edit buttons and category tags
         $patterns = array('!<div class="toc">.*?(</div>\n</div>)!s',
-                          '#<!-- EDIT.*? \[(\d*-\d*)\] -->#e',
+                          '#<!-- EDIT.*? \[(\d*-\d*)\] -->#',
                           '!<div class="category">.*?</div>!s');
         $replace  = array('','','');
         $text = preg_replace($patterns,$replace,$text);

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -111,10 +111,10 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
      * Generate wiki output from instructions
      *
      * @param $data array as returned by handle()
-     * @param &$R Doku_Renderer_xhtml
+     * @param $R Doku_Renderer_xhtml
      * @return bool|void
      */
-    function _showData($data, &$R) {
+    function _showData($data, $R) {
 
         if(!array_key_exists('template', $data)) {
             // If keyword "template" not present, we can leave

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -308,8 +308,11 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
         // If for some reason there are no instructions, don't do anything
         // (Maybe for cache handling one should hand the template file name to the
         // metadata, even though the file does not exist)
-        if(!is_string($file)) parent::saveData($data, $id, $renderer->meta['title']);
-        $renderer->meta['relation']['haspart'][$file] = array('owner'=>$this->getPluginName());
+        if($instr == 0 || $instr == -1) {
+                if(!is_string($file)) parent::saveData($data, $id, $renderer->meta['title']);
+                $renderer->meta['relation']['haspart'][$file] = array('owner'=>$this->getPluginName());
+                return;
+        }
 
         // Remove document_start and document_end from instructions
         array_shift($instr);

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -13,6 +13,7 @@ if(file_exists($dataEntryFile)){
     msg('datatemplate: Cannot find Data plugin.', -1);
     return;
 }
+require_once(DOKU_INC . 'inc/common.php'); // for dformat()
 
 class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
 
@@ -264,6 +265,9 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
                     $outs[] = $val;
                     break;
+		 case 'timestamp':
+                    $outs[] = dformat($val);
+                    break;
                 default:
                     $val = $this->dthlp->_addPrePostFixes($column['type'], $val);
                     if(substr($type,0,3) == 'img'){
@@ -278,7 +282,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
                     }else{
                         $outs[] = $val;
                     }
-            }    //todo add type 'timestamp' ... returns html..
+            }
         }
         return join(', ',$outs);
     }

--- a/syntax/inc/cache.php
+++ b/syntax/inc/cache.php
@@ -37,7 +37,7 @@ class datatemplate_cache {
     public function checkAndBuildCache($data, $sql, &$dtlist) {
         // We know that the datatemplate list has a datahelper.
         /** @var $sqlite helper_plugin_sqlite */
-        $sqlite = $dtlist->dthlp->_getDB();
+        $sqlite = $dtlist->dthlp->getDB();
 
         // Build minimalistic data array for checking the cache
         $dtcc = array();
@@ -52,8 +52,7 @@ class datatemplate_cache {
         // to the pageid are actually considered.
         $dtcc['filter'] = $data['filter'];
         $sqlcc = $dtlist->_buildSQL($dtcc);
-        $res = $sqlite->query($sqlcc);
-        $pageids = $sqlite->res2arr($res, $assoc = false);
+        $pageids = $sqlite->queryAll($sqlcc);
 
         // Ask dokuwiki for cache file name
         $cachefile = getCacheName($sql, '.datatemplate');
@@ -71,8 +70,7 @@ class datatemplate_cache {
             }
         }
         if(!$cachedate || $latest > (int) $cachedate  || isset($_REQUEST['purge'])) {
-            $res = $sqlite->query($sql);
-            $rows = $sqlite->res2arr($res, $assoc = false);
+            $rows = $sqlite->queryAll($sql);
             file_put_contents($cachefile, serialize($rows), LOCK_EX);
         } else {
             // We arrive here when the cache seems up-to-date. However,

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -94,7 +94,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         unset($_REQUEST['dataofs']);
         unset($_REQUEST['dataflt']);
 
-        $sql = parent::_buildSQL($data);
+        $sql = parent::buildSQL($data);
 
         // Restore removed fields
         $data['limit'] = $limit;
@@ -223,9 +223,9 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
             }
             $replacers['vals_id'][$i] = array();
             $replacers['raw_vals'] = array();
-            foreach($row as $num => $cval) {
+            foreach(array_values($row) as $num => $cval) {
                 $replacers['raw_vals'][] = trim($cval);
-                $replacers['vals_id'][$i][] = $this->dthlp->_formatData($data['cols'][$clist[$num]], $cval, $R);
+                $replacers['vals_id'][$i][] = $this->dthlp->formatData($data['cols'][$clist[$num]], $cval, $R);
             }
 
             // First do raw replacements
@@ -280,7 +280,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         $text = '';
         // Add pagination controls
         if($data['limit']){
-            $params = $this->dthlp->_a2ua('dataflt',$_REQUEST['dataflt']);
+            $params = $this->dthlp->a2ua('dataflt',$_REQUEST['dataflt']);
             //$params['datasrt'] = $_REQUEST['datasrt'];
             $offset = (int) $_REQUEST['dataofs'];
             if($offset){
@@ -338,7 +338,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         foreach($data['headers'] as $k => $v) {
             $keys[$v] = $k;
         }
-        $filters = $this->dthlp->_get_filters();
+        $filters = $this->dthlp->getFilters();
         if(!$datarows) return $out;
         foreach($datarows as $dr) {
             $matched = True;

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -206,7 +206,9 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         $rawFile = io_readfile($file);
 
         // embed the included page
-        $R->doc .= "<div class=\"${data['classes']}\">";
+        if(strcmp($data['classes'],'nodiv') !== 0){
+            $R->doc .= "<div class=\"${data['classes']}\">";
+        }
 
         // We only want to call the parser once, so first do all the raw replacements and concatenate
         // the strings.
@@ -257,8 +259,10 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         $text = preg_replace('/@@.*?@@/', '', $text);
 
         $R->doc .= $text;
-        $R->doc .= '</div>';
 
+        if(strcmp($data['classes'],'nodiv') !== 0){
+            $R->doc .= '</div>';
+        }
         return true;
     }
 

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -394,7 +394,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         return preg_match('/^\s*'.$regex.'$/im', $haystack);
     }
 
-    function nullList($data, $clist, &$R) {
+    function nullList($data, $clist, $R) {
         $R->doc .= '<div class="templatelist">Nothing.</div>';
     }
 }

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -241,7 +241,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         $text = p_render('xhtml', $instr, $info);
         // remove toc, section edit buttons and category tags
         $patterns = array('!<div class="toc">.*?(</div>\n</div>)!s',
-                          '#<!-- SECTION \[(\d*-\d*)\] -->#e',
+                          '#<!-- SECTION \[(\d*-\d*)\] -->#',
                           '!<div class="category">.*?</div>!s');
         $replace  = array('','','');
         $text = preg_replace($patterns,$replace,$text);


### PR DESCRIPTION
I experienced a fatal rendering error when giving the name of a non-existing template because array_shift() did not get an array but a number. This check should solve the problem. For some reason, I cannot reproduce the error now. 